### PR TITLE
feat: 고인정보 생성시 활성 계정으로 전환

### DIFF
--- a/src/main/java/org/accompany/backend/domain/deceasedProfile/service/DeceasedProfileServiceImpl.java
+++ b/src/main/java/org/accompany/backend/domain/deceasedProfile/service/DeceasedProfileServiceImpl.java
@@ -48,11 +48,9 @@ public class DeceasedProfileServiceImpl implements DeceasedProfileService {
 
         deceasedProfileRepository.save(profile);
 
-        if (user.getActiveDeceasedProfile() == null) {
-            user.updateActiveDeceasedProfile(profile);
-            log.info("[DeceasedProfile] 첫 고인 정보 생성으로 현재 고인 정보 설정 - userId={}, deceasedProfileId={}",
-                    userId, profile.getDeceasedProfileId());
-        }
+        user.updateActiveDeceasedProfile(profile);
+        log.info("[DeceasedProfile] 고인 정보 생성으로 현재 고인 정보 설정 변경 - userId={}, deceasedProfileId={}",
+                userId, profile.getDeceasedProfileId());
 
         log.info("[DeceasedProfile] 고인 정보 생성 완료 - userId={}, deceasedProfileId={}",
                 userId, profile.getDeceasedProfileId());


### PR DESCRIPTION
## 📌 Related Issue

## 🚀 Description

## 📢 Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created deceased profiles are now automatically set as the active profile, regardless of any previously active profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->