### PR TITLE
feat: 설문조사 다시 하기 reset API 추가

### DIFF
--- a/src/main/java/org/accompany/backend/domain/checklist/repository/UserDocumentChecklistRepository.java
+++ b/src/main/java/org/accompany/backend/domain/checklist/repository/UserDocumentChecklistRepository.java
@@ -1,7 +1,11 @@
 package org.accompany.backend.domain.checklist.repository;
 
 import org.accompany.backend.domain.checklist.entity.UserDocumentChecklist;
+import org.accompany.backend.domain.deceasedProfile.entity.DeceasedProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -10,4 +14,7 @@ public interface UserDocumentChecklistRepository extends JpaRepository<UserDocum
 	Optional<UserDocumentChecklist> findByUserDocumentChecklistId(Long userDocumentChecklistId);
 	Optional<UserDocumentChecklist> findByProcedureDocumentProcedureDocumentIdAndDeceasedProfileDeceasedProfileId(Long procedureDocumentId, Long profileId);
 
+	@Modifying
+	@Query("delete from UserDocumentChecklist udc where udc.deceasedProfile = :deceasedProfile")
+	void deleteAllByDeceasedProfile(@Param("deceasedProfile") DeceasedProfile deceasedProfile);
 }

--- a/src/main/java/org/accompany/backend/domain/checklist/repository/UserProcedureChecklistRepository.java
+++ b/src/main/java/org/accompany/backend/domain/checklist/repository/UserProcedureChecklistRepository.java
@@ -1,7 +1,9 @@
 package org.accompany.backend.domain.checklist.repository;
 
 import org.accompany.backend.domain.checklist.entity.UserProcedureChecklist;
+import org.accompany.backend.domain.deceasedProfile.entity.DeceasedProfile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -30,4 +32,8 @@ public interface UserProcedureChecklistRepository extends JpaRepository<UserProc
 			Long procedureId,
 			Long profileId
 	);
+
+	@Modifying
+	@Query("delete from UserProcedureChecklist upc where upc.deceasedProfile = :deceasedProfile")
+	void deleteAllByDeceasedProfile(@Param("deceasedProfile") DeceasedProfile deceasedProfile);
 }

--- a/src/main/java/org/accompany/backend/domain/survey/controller/SurveyController.java
+++ b/src/main/java/org/accompany/backend/domain/survey/controller/SurveyController.java
@@ -63,4 +63,13 @@ public class SurveyController {
     ) {
         return ApiResponse.success(SuccessCode.OK, surveyService.saveTempSurvey(principal.getUserId(), request));
     }
+
+    @PostMapping("/reset")
+    @Operation(summary = "설문조사 다시 하기", description = "체크리스트와 응답을 모두 삭제하고 설문 상태를 IN_PROGRESS로 되돌립니다.")
+    public ResponseEntity<ApiResponse<Void>> resetSurvey(
+            @AuthenticationPrincipal CustomUserPrincipal principal
+    ) {
+        surveyService.resetSurvey(principal.getUserId());
+        return ApiResponse.success(SuccessCode.OK);
+    }
 }

--- a/src/main/java/org/accompany/backend/domain/survey/service/SurveyService.java
+++ b/src/main/java/org/accompany/backend/domain/survey/service/SurveyService.java
@@ -14,6 +14,7 @@ public interface SurveyService {
     void skipSurvey(Long userId);
     SurveyTempSaveRes saveTempSurvey(Long userId, SurveySaveReq request);
     SurveySubmitRes submitSurvey(Long userId, SurveySaveReq request);
+    void resetSurvey(Long userId);
 
     LocalDateTime calculateDueDate(Procedure procedure, LocalDate dateOfDeath);
 }

--- a/src/main/java/org/accompany/backend/domain/survey/service/SurveyServiceImpl.java
+++ b/src/main/java/org/accompany/backend/domain/survey/service/SurveyServiceImpl.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.accompany.backend.domain.checklist.entity.UserDocumentChecklist;
 import org.accompany.backend.domain.checklist.entity.UserProcedureChecklist;
 import org.accompany.backend.domain.checklist.repository.ChecklistBulkRepository;
+import org.accompany.backend.domain.checklist.repository.UserDocumentChecklistRepository;
+import org.accompany.backend.domain.checklist.repository.UserProcedureChecklistRepository;
 import org.accompany.backend.domain.deceasedProfile.entity.DeceasedProfile;
 import org.accompany.backend.domain.deceasedProfile.entity.SurveyStatus;
 import org.accompany.backend.domain.procedure.entity.DueDateType;
@@ -50,6 +52,8 @@ public class SurveyServiceImpl implements SurveyService {
     private final UserRepository userRepository;
     private final SurveyAnswerRepository surveyAnswerRepository;
     private final SurveyResponseRepository surveyResponseRepository;
+    private final UserProcedureChecklistRepository userProcedureChecklistRepository;
+    private final UserDocumentChecklistRepository userDocumentChecklistRepository;
 
 
     @Override
@@ -325,6 +329,33 @@ public class SurveyServiceImpl implements SurveyService {
                 procedureChecklists.size(),
                 documentChecklists.size()
         );
+    }
+
+    @Override
+    @Transactional
+    public void resetSurvey(Long userId) {
+        log.info("[Survey] 설문조사 다시 하기 시작 - userId={}", userId);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.error("[Survey] 사용자 조회 실패 - userId={}", userId);
+                    return new BusinessException(ErrorCode.USER_NOT_FOUND);
+                });
+
+        DeceasedProfile deceasedProfile = user.getActiveDeceasedProfile();
+        if (deceasedProfile == null) {
+            log.error("[Survey] 활성 고인 프로필 없음 - userId={}", userId);
+            throw new BusinessException(ErrorCode.DECEASED_PROFILE_NOT_FOUND);
+        }
+
+        userProcedureChecklistRepository.deleteAllByDeceasedProfile(deceasedProfile);
+        userDocumentChecklistRepository.deleteAllByDeceasedProfile(deceasedProfile);
+        surveyResponseRepository.deleteAllByDeceasedProfile(deceasedProfile);
+
+        deceasedProfile.updateStatus(SurveyStatus.IN_PROGRESS);
+
+        log.info("[Survey] 설문조사 다시 하기 완료 - userId={}, deceasedProfileId={}",
+                userId, deceasedProfile.getDeceasedProfileId());
     }
 
 }


### PR DESCRIPTION
## 📌 Related Issue
#98 
## 🚀 Description
설문조사 다시 하기 reset API 추가
 checklist 생성전 단계로, 생성되어있는 checklist 를 db 에서 제거 후, deceased_profile_status 를 In_Progress 상태로 변경
## 📢 Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now reset their survey progress. This clears all associated checklist entries and responses, allowing them to restart the survey workflow from the beginning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->