### PR TITLE
feature/calendar조회 userId/deceasedProfileId 구현 #116

### DIFF
--- a/src/main/java/org/accompany/backend/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/org/accompany/backend/domain/calendar/controller/CalendarController.java
@@ -22,16 +22,55 @@ public class CalendarController {
 
 	private final CalendarService calendarService;
 
+	// =====================================================
+	// 1. USER 전체 - 월간 및 일간
+	// =====================================================
+
+	/**
+	 * 사용자 전체 캘린더 (월간 통합 조회)
+	 * GET /api/v1/calendars?year=2033&month=3
+	 */
+	@GetMapping
+	@Operation(summary = "사용자 전체 월간 캘린더 조회", description = "체크리스트에서 생성된 due date를 기반으로 사용자가 가진 모든 고인 프로필의 캘린더 이벤트를 통합 조회합니다. 입력예시: year: 조회 연도 (yyyy) | month: MM)")
+	public ResponseEntity<ApiResponse<List<CalendarEventRes>>> getMonthlyEventsByUser(
+			@AuthenticationPrincipal CustomUserPrincipal principal,
+			@RequestParam int year,
+			@RequestParam int month
+	) {
+		return ApiResponse.success(
+				SuccessCode.OK,
+				calendarService.getMonthlyEventsByUser(principal.getUserId(), year, month)
+		);
+	}
+
+	/**
+	 * 일별 캘린더 이벤트 조회
+	 * GET /api/v1/calendars/daily?date=2033-03-03
+	 */
+	@Operation(summary = "사용자 전체 일간 캘린더 조회", description = "체크리스트에서 생성된 due date를 기반으로 특정 날짜 기준으로 사용자가 가진 모든 고인 프로필의 캘린더 이벤트를 통합 조회합니다. 입력예시: yyyy-MM-dd 형식")
+	@GetMapping("/daily")
+	public ResponseEntity<ApiResponse<List<CalendarEventRes>>> getDailyEventsByUser(
+			@AuthenticationPrincipal CustomUserPrincipal principal,
+			@RequestParam String date  // yyyy-MM-dd
+	) {
+		return ApiResponse.success(
+				SuccessCode.OK,
+				calendarService.getDailyEventsByUser(principal.getUserId(), date));
+	}
+
+	// =====================================================
+	// 2. DECEASED_PROFILE - 월간 및 일간
+	// =====================================================
 	/**
 	 * 월별 캘린더 이벤트 조회
-	 * GET /api/v1/calendar/{deceasedProfileId}?year=2033&month=6
+	 * GET /api/v1/calendars/{deceasedProfileId}?year=2033&month=6
 	 */
 	@GetMapping("/{deceasedProfileId}")
 	@Operation(
-			summary = "월별 캘린더 조회",
-			description = "특정 고인 프로필의 월간 달력을 조회합니다. (입력: year - yyyy | month - MM 형식)"
+			summary = "고인 프로필 월간 캘린더 조회",
+			description = "특정 고인 프로필 기준으로 해당 프로필의 캘린더 이벤트를 조회합니다. (입력: year - yyyy | month - MM 형식)"
 	)
-	public ResponseEntity<ApiResponse<List<CalendarEventRes>>> getMonthlyEvents(
+	public ResponseEntity<ApiResponse<List<CalendarEventRes>>> getMonthlyEventsByDeceasedProfile(
 			@AuthenticationPrincipal CustomUserPrincipal principal,
 			@PathVariable Long deceasedProfileId,
 			@RequestParam int year,
@@ -40,7 +79,8 @@ public class CalendarController {
 
 		return ApiResponse.success(
 				SuccessCode.OK,
-				calendarService.getMonthlyEvents(
+				calendarService.getMonthlyEventsByDeceasedProfile(
+						principal,
 						deceasedProfileId,
 						year,
 						month
@@ -50,14 +90,14 @@ public class CalendarController {
 
 	/**
 	 * 일별 캘린더 이벤트 조회
-	 * GET /api/v1/calendar/{deceasedProfileId}/daily?date=2033-03-03
+	 * GET /api/v1/calendars/{deceasedProfileId}/daily?date=2033-03-03
 	 */
 	@GetMapping("/{deceasedProfileId}/daily")
 	@Operation(
-			summary = "일별 캘린더 조회",
-			description = "특정 고인 프로필의 일간 달력을 조회합니다. (입력: yyyy-MM-dd 형식)"
+			summary = "고인 프로필 일간 캘린더 조회",
+			description = " 특정 고인 프로필 기준으로 해당 날짜의 캘린더 이벤트를 조회합니다. (입력: yyyy-MM-dd 형식)"
 	)
-	public ResponseEntity<ApiResponse<List<CalendarEventRes>>> getDailyEvents(
+	public ResponseEntity<ApiResponse<List<CalendarEventRes>>> getDailyEventsByDeceasedProfile(
 			@AuthenticationPrincipal CustomUserPrincipal principal,
 			@PathVariable Long deceasedProfileId,
 			@RequestParam String date
@@ -65,7 +105,8 @@ public class CalendarController {
 
 		return ApiResponse.success(
 				SuccessCode.OK,
-				calendarService.getDailyEvents(
+				calendarService.getDailyEventsByDeceasedProfile(
+						principal,
 						deceasedProfileId,
 						date
 				)

--- a/src/main/java/org/accompany/backend/domain/calendar/entity/CalendarEvent.java
+++ b/src/main/java/org/accompany/backend/domain/calendar/entity/CalendarEvent.java
@@ -30,7 +30,6 @@ public class CalendarEvent extends BaseEntity {
     @JoinColumn(name = "deceased_profile_id")
     private DeceasedProfile deceasedProfile;
 
-
     /**
      * 체크리스트 기반 일정이면 연결
      * 일반 일정/구글 일정이면 null
@@ -42,7 +41,6 @@ public class CalendarEvent extends BaseEntity {
     @Column(nullable = false, length = 200)
     private String title;
 
-    @Lob
     @Column(columnDefinition = "TEXT")
     private String description;
 

--- a/src/main/java/org/accompany/backend/domain/calendar/event/ChecklistCreatedEvent.java
+++ b/src/main/java/org/accompany/backend/domain/calendar/event/ChecklistCreatedEvent.java
@@ -1,11 +1,6 @@
 package org.accompany.backend.domain.calendar.event;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-
-@Getter
-@RequiredArgsConstructor
-public class ChecklistCreatedEvent {
-
-	private final Long deceasedProfileId;
+public record ChecklistCreatedEvent(
+		Long deceasedProfileId
+) {
 }

--- a/src/main/java/org/accompany/backend/domain/calendar/listener/CalendarEventListener.java
+++ b/src/main/java/org/accompany/backend/domain/calendar/listener/CalendarEventListener.java
@@ -35,7 +35,7 @@ public class CalendarEventListener {
 	@Transactional
 	public void handleChecklistCreated(ChecklistCreatedEvent event) {
 
-		Long deceasedProfileId = event.getDeceasedProfileId();
+		Long deceasedProfileId = event.deceasedProfileId();
 
 		log.info(
 				"[Calendar] 체크리스트 기반 일정 생성 시작 - deceasedProfileId={}",

--- a/src/main/java/org/accompany/backend/domain/calendar/repository/CalendarEventRepository.java
+++ b/src/main/java/org/accompany/backend/domain/calendar/repository/CalendarEventRepository.java
@@ -20,13 +20,42 @@ public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Lo
 	@Query("""
 			    SELECT ce
 			    FROM CalendarEvent ce
-			    WHERE ce.deceasedProfile.deceasedProfileId = :deceasedProfileId
+			
+			    LEFT JOIN FETCH ce.deceasedProfile dp
+			    LEFT JOIN FETCH ce.userProcedureChecklist upc
+			    LEFT JOIN FETCH upc.procedure p
+			    LEFT JOIN FETCH p.procedureCategory pc
+			
+			    WHERE dp.deceasedProfileId = :deceasedProfileId
 			      AND ce.startAt <= :endDate
 			      AND (ce.endAt IS NULL OR ce.endAt >= :startDate)
+			
 			    ORDER BY ce.startAt ASC
 			""")
 	List<CalendarEvent> findByDeceasedProfileIdAndDateRange(
 			@Param("deceasedProfileId") Long deceasedProfileId,
+			@Param("startDate") LocalDateTime startDate,
+			@Param("endDate") LocalDateTime endDate
+	);
+
+
+	@Query("""
+			    SELECT ce
+			    FROM CalendarEvent ce
+			
+			    LEFT JOIN FETCH ce.deceasedProfile dp
+			    LEFT JOIN FETCH ce.userProcedureChecklist upc
+			    LEFT JOIN FETCH upc.procedure p
+			    LEFT JOIN FETCH p.procedureCategory pc
+			
+			    WHERE ce.user.userId = :userId
+			      AND ce.startAt <= :endDate
+			      AND (ce.endAt IS NULL OR ce.endAt >= :startDate)
+			
+			    ORDER BY ce.startAt ASC
+			""")
+	List<CalendarEvent> findByUserIdAndDateRange(
+			@Param("userId") Long userId,
 			@Param("startDate") LocalDateTime startDate,
 			@Param("endDate") LocalDateTime endDate
 	);
@@ -40,6 +69,7 @@ public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Lo
 	Set<Long> findChecklistIdsByDeceasedProfileId(
 			@Param("deceasedProfileId") Long deceasedProfileId
 	);
+
 
 	/**
 	 * Google Event ID 조회

--- a/src/main/java/org/accompany/backend/domain/calendar/service/CalendarService.java
+++ b/src/main/java/org/accompany/backend/domain/calendar/service/CalendarService.java
@@ -1,18 +1,29 @@
 package org.accompany.backend.domain.calendar.service;
 
 import org.accompany.backend.domain.calendar.dto.response.CalendarEventRes;
+import org.accompany.backend.global.security.principal.CustomUserPrincipal;
 
 import java.util.List;
 
 public interface CalendarService {
 
 	/**
-	 * 월별 이벤트 조회
+	 * 사용자 전체 월간 캘린더 조회
 	 */
-	List<CalendarEventRes> getMonthlyEvents(Long userId, int year, int month);
+	List<CalendarEventRes> getMonthlyEventsByUser( Long userId, int year, int month );
 
 	/**
-	 * 일별 이벤트 조회
+	 * 사용자 전체 일간 캘린더 조회
 	 */
-	List<CalendarEventRes> getDailyEvents(Long userId, String dateStr);
+	List<CalendarEventRes> getDailyEventsByUser( Long userId, String date );
+
+	/**
+	 * 특정 고인 프로필 월간 조회
+	 */
+	List<CalendarEventRes> getMonthlyEventsByDeceasedProfile( CustomUserPrincipal principal, Long deceasedProfileId, int year, int month );
+
+	/**
+	 * 특정 고인 프로필 일간 조회
+	 */
+	List<CalendarEventRes> getDailyEventsByDeceasedProfile( CustomUserPrincipal principal, Long deceasedProfileId, String date );
 }

--- a/src/main/java/org/accompany/backend/domain/calendar/service/CalendarServiceImpl.java
+++ b/src/main/java/org/accompany/backend/domain/calendar/service/CalendarServiceImpl.java
@@ -4,9 +4,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.accompany.backend.domain.calendar.dto.response.CalendarEventRes;
 import org.accompany.backend.domain.calendar.entity.CalendarEvent;
-import org.accompany.backend.domain.calendar.entity.EventType;
 import org.accompany.backend.domain.calendar.repository.CalendarEventRepository;
-import org.accompany.backend.domain.checklist.entity.UserProcedureChecklist;
+import org.accompany.backend.global.security.principal.CustomUserPrincipal;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,14 +25,101 @@ public class CalendarServiceImpl implements CalendarService {
 	private final CalendarEventRepository calendarEventRepository;
 
 	@Override
-	public List<CalendarEventRes> getMonthlyEvents(
+	public List<CalendarEventRes> getMonthlyEventsByUser(Long userId, int year, int month) {
+
+		log.info(
+				"=== CalendarServiceImpl.getMonthlyEventsByUser === userId: {}, year: {}, month: {}",
+				userId, year, month );
+
+		YearMonth yearMonth = YearMonth.of(year, month);
+
+		LocalDateTime startOfMonth =
+				yearMonth.atDay(1).atStartOfDay();
+
+		LocalDateTime endOfMonth =
+				yearMonth.atEndOfMonth().atTime(23, 59, 59);
+
+		List<CalendarEventRes> result =
+				calendarEventRepository
+						.findByUserIdAndDateRange(
+								userId,
+								startOfMonth,
+								endOfMonth
+						)
+						.stream()
+						.map(this::fromCalendarEvent)
+						.sorted(
+								Comparator.comparing(
+										CalendarEventRes::startAt,
+										Comparator.nullsLast(
+												Comparator.naturalOrder()
+										)
+								)
+						)
+						.toList();
+
+		log.info(
+				"=== CalendarServiceImpl.getMonthlyEventsByUser === userId: {}, count: {}",
+				userId, result.size()
+		);
+
+		return result;
+	}
+
+	@Override
+	public List<CalendarEventRes> getDailyEventsByUser(Long userId, String dateStr) {
+		log.info(
+				"=== CalendarServiceImpl.getDailyEventsByUser 시작 === userId: {}, date: {}",
+				userId, dateStr );
+
+		LocalDate date = LocalDate.parse(dateStr);
+
+		LocalDateTime startOfDay =
+				date.atStartOfDay();
+
+		LocalDateTime endOfDay =
+				date.atTime(23, 59, 59);
+
+		List<CalendarEventRes> result =
+				calendarEventRepository
+						.findByUserIdAndDateRange(
+								userId,
+								startOfDay,
+								endOfDay
+						)
+						.stream()
+						.map(this::fromCalendarEvent)
+						.sorted(
+								Comparator.comparing(
+										CalendarEventRes::startAt,
+										Comparator.nullsLast(
+												Comparator.naturalOrder()
+										)
+								)
+						)
+						.toList();
+
+		log.info(
+				"=== CalendarServiceImpl.getDailyEventsByUser 종료 === userId: {}, count: {}",
+				userId, result.size() );
+
+		return result;
+
+
+	}
+
+	@Override
+	@PreAuthorize("@calendarSecurity.isOwner(principal.userId, #deceasedProfileId)")
+	public List<CalendarEventRes> getMonthlyEventsByDeceasedProfile(
+			CustomUserPrincipal principal,
 			Long deceasedProfileId,
 			int year,
 			int month
 	) {
 
 		log.info(
-				"=== getMonthlyEvents 시작 === deceasedProfileId: {}, year: {}, month: {}",
+				"=== CalendarServiceImpl.getMonthlyEventsByDeceasedProfile 시작 === userId: {}, deceasedProfileId: {}, year: {}, month: {}",
+				principal.getUserId(),
 				deceasedProfileId,
 				year,
 				month
@@ -50,7 +137,7 @@ public class CalendarServiceImpl implements CalendarService {
 				getEvents(deceasedProfileId, startOfMonth, endOfMonth);
 
 		log.info(
-				"=== getMonthlyEvents 종료 === deceasedProfileId: {}, 조회된 이벤트 수: {}",
+				"=== CalendarServiceImpl.getMonthlyEventsByDeceasedProfile 종료 === deceasedProfileId: {}, 조회된 이벤트 수: {}",
 				deceasedProfileId,
 				result.size()
 		);
@@ -59,13 +146,16 @@ public class CalendarServiceImpl implements CalendarService {
 	}
 
 	@Override
-	public List<CalendarEventRes> getDailyEvents(
+	@PreAuthorize("@calendarSecurity.isOwner(principal.userId, #deceasedProfileId)")
+	public List<CalendarEventRes> getDailyEventsByDeceasedProfile(
+			CustomUserPrincipal principal,
 			Long deceasedProfileId,
 			String dateStr
 	) {
 
 		log.info(
-				"=== getDailyEvents 시작 === deceasedProfileId: {}, date: {}",
+				"=== CalendarServiceImpl.getDailyEventsByDeceasedProfile 시작 === userId: {}, deceasedProfileId: {}, date: {}",
+				principal.getUserId(),
 				deceasedProfileId,
 				dateStr
 		);
@@ -80,7 +170,7 @@ public class CalendarServiceImpl implements CalendarService {
 				getEvents(deceasedProfileId, startOfDay, endOfDay);
 
 		log.info(
-				"=== getDailyEvents 종료 === deceasedProfileId: {}, 조회된 이벤트 수: {}",
+				"=== CalendarServiceImpl.getDailyEventsByDeceasedProfile 종료 === deceasedProfileId: {}, 조회된 이벤트 수: {}",
 				deceasedProfileId,
 				result.size()
 		);
@@ -128,18 +218,15 @@ public class CalendarServiceImpl implements CalendarService {
 				event.getCalendarEventId(),
 
 				event.getDeceasedProfile() != null
-						? event.getDeceasedProfile()
-						.getDeceasedProfileId()
+						? event.getDeceasedProfile().getDeceasedProfileId()
 						: null,
 
 				event.getDeceasedProfile() != null
-						? event.getDeceasedProfile()
-						.getName()
+						? event.getDeceasedProfile().getName()
 						: null,
 
 				event.getUserProcedureChecklist() != null
-						? event.getUserProcedureChecklist()
-						.getUserProcedureChecklistId()
+						? event.getUserProcedureChecklist().getUserProcedureChecklistId()
 						: null,
 
 				event.getTitle(),

--- a/src/main/java/org/accompany/backend/domain/deceasedProfile/repository/DeceasedProfileRepository.java
+++ b/src/main/java/org/accompany/backend/domain/deceasedProfile/repository/DeceasedProfileRepository.java
@@ -7,7 +7,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface DeceasedProfileRepository extends JpaRepository<DeceasedProfile, Long> {
-    List<DeceasedProfile> findAllByUserUserIdOrderByDateOfDeathDescCreatedAtDesc(Long userId);
-    Optional<DeceasedProfile> findByDeceasedProfileIdAndUserUserId(Long deceasedProfileId, Long userId);
-    boolean existsByUserUserId(Long userId);
+	List<DeceasedProfile> findAllByUserUserIdOrderByDateOfDeathDescCreatedAtDesc(Long userId);
+	Optional<DeceasedProfile> findByDeceasedProfileIdAndUserUserId(Long deceasedProfileId, Long userId);
+	boolean existsByUserUserId(Long userId);
+
+
+	boolean existsByDeceasedProfileIdAndUserUserId(Long deceasedProfileId, Long userId);
 }

--- a/src/main/java/org/accompany/backend/global/security/authorization/CalendarSecurity.java
+++ b/src/main/java/org/accompany/backend/global/security/authorization/CalendarSecurity.java
@@ -1,0 +1,24 @@
+package org.accompany.backend.global.security.authorization;
+
+import lombok.RequiredArgsConstructor;
+import org.accompany.backend.domain.deceasedProfile.repository.DeceasedProfileRepository;
+import org.springframework.stereotype.Component;
+
+@Component("calendarSecurity")
+@RequiredArgsConstructor
+public class CalendarSecurity {
+
+	private final DeceasedProfileRepository deceasedProfileRepository;
+
+	public boolean isOwner(
+			Long userId,
+			Long deceasedProfileId
+	) {
+
+		return deceasedProfileRepository
+				.existsByDeceasedProfileIdAndUserUserId(
+						deceasedProfileId,
+						userId
+				);
+	}
+}


### PR DESCRIPTION
## 📌 Related Issue
calendar조회 userId/deceasedProfileId 구현 #116 

## 🚀 Description
calendar에서 처리 일정 조회시 userId/deceasedProfileId로 조회하도록 구현

## 📢 Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added dedicated calendar endpoints for authenticated users to retrieve personal events with monthly and daily filtering options.

* **Refactor**
  * Reorganized deceased profile calendar endpoints with improved clarity and explicit naming conventions.
  * Optimized calendar event data retrieval performance through enhanced query efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Goorm-Deep-Dive/backend/pull/117)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->