### PR TITLE
feat: FCM 발송 실패 시 재시도 로직 추가

### DIFF
--- a/src/main/java/org/accompany/backend/domain/notification/service/FcmSendServiceImpl.java
+++ b/src/main/java/org/accompany/backend/domain/notification/service/FcmSendServiceImpl.java
@@ -66,15 +66,16 @@ public class FcmSendServiceImpl implements FcmSendService {
             }
         }
 
+        MessagingErrorCode finalErrorCode = (lastException != null) ? lastException.getMessagingErrorCode() : null;
         log.error("[FCM] 발송 최종 실패 - notificationId={}, errorCode={}",
-                payload.notificationId(), lastException.getMessagingErrorCode());
-        return FcmSendResult.failure("FCM_SEND_FAILED:" + lastException.getMessagingErrorCode());
+                payload.notificationId(), finalErrorCode);
+        return FcmSendResult.failure("FCM_SEND_FAILED:" + finalErrorCode);
     }
 
     private boolean isRetryable(MessagingErrorCode errorCode) {
         if (errorCode == null) return false;
         return switch (errorCode) {
-            case UNREGISTERED, INVALID_ARGUMENT -> false;
+            case UNREGISTERED, INVALID_ARGUMENT, SENDER_ID_MISMATCH, THIRD_PARTY_AUTH_ERROR -> false;
             default -> true;
         };
     }

--- a/src/main/java/org/accompany/backend/domain/notification/service/FcmSendServiceImpl.java
+++ b/src/main/java/org/accompany/backend/domain/notification/service/FcmSendServiceImpl.java
@@ -3,6 +3,7 @@ package org.accompany.backend.domain.notification.service;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.Notification;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,9 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class FcmSendServiceImpl implements FcmSendService {
+
+    private static final int MAX_RETRIES = 3;
+    private static final long RETRY_BACKOFF_MS = 500L;
 
     private final FirebaseMessaging firebaseMessaging;
 
@@ -34,16 +38,44 @@ public class FcmSendServiceImpl implements FcmSendService {
                 ))
                 .build();
 
-        try {
-            String messageId = firebaseMessaging.send(message);
-            log.info("[FCM] 발송 성공 - notificationId={}, messageId={}",
-                    payload.notificationId(), messageId);
-            return FcmSendResult.success(messageId);
+        FirebaseMessagingException lastException = null;
 
-        } catch (FirebaseMessagingException e) {
-            log.error("[FCM] 발송 실패 - notificationId={}, errorCode={}, reason={}",
-                    payload.notificationId(), e.getErrorCode(), e.getMessage());
-            return FcmSendResult.failure("FCM_SEND_FAILED:" + e.getErrorCode());
+        for (int attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+            try {
+                String messageId = firebaseMessaging.send(message);
+                log.info("[FCM] 발송 성공 - notificationId={}, messageId={}, attempt={}",
+                        payload.notificationId(), messageId, attempt);
+                return FcmSendResult.success(messageId);
+
+            } catch (FirebaseMessagingException e) {
+                lastException = e;
+                log.warn("[FCM] 발송 실패 (시도 {}/{}) - notificationId={}, errorCode={}, reason={}",
+                        attempt, MAX_RETRIES, payload.notificationId(),
+                        e.getMessagingErrorCode(), e.getMessage());
+
+                if (!isRetryable(e.getMessagingErrorCode()) || attempt == MAX_RETRIES) {
+                    break;
+                }
+
+                try {
+                    Thread.sleep(RETRY_BACKOFF_MS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
         }
+
+        log.error("[FCM] 발송 최종 실패 - notificationId={}, errorCode={}",
+                payload.notificationId(), lastException.getMessagingErrorCode());
+        return FcmSendResult.failure("FCM_SEND_FAILED:" + lastException.getMessagingErrorCode());
+    }
+
+    private boolean isRetryable(MessagingErrorCode errorCode) {
+        if (errorCode == null) return false;
+        return switch (errorCode) {
+            case UNREGISTERED, INVALID_ARGUMENT -> false;
+            default -> true;
+        };
     }
 }


### PR DESCRIPTION
## 📌 Related Issue
#133 
## 🚀 Description
에러코드가 없거나, 메시지 자체오류로 받는 이용자가 오해소지가 있는경우, fcm 토큰에 오류가 있어 재 발송을 해도 실패할수밖에 없는 상황을 제외한 실패건 제외하여 총 3회 500ms 의 텀으로 재발송 로직 추가
## 📢 Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced push notification delivery reliability with automatic retry logic for failed sends, including configurable retry limits and backoff intervals between attempts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Goorm-Deep-Dive/backend/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->